### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,27 +268,27 @@ Further development of *LSSEFT* depends on demonstrating its usefulness to fundi
 
 The effective field theory of large-scale structure was proposed by
 
-- Baumann, Nicolis, Senatore & Zaldarriaga, _Cosmological Non-Linearities as an Effective Fluid_, JCAP **1207** (2012) 051 [DOI:10.1088/1475-7516/2012/07/051](http://dx.doi.org/10.1088/1475-7516/2012/07/051), [arXiv:1004.2488](http://arxiv.org/abs/arXiv:1004.2488)
+- Baumann, Nicolis, Senatore & Zaldarriaga, _Cosmological Non-Linearities as an Effective Fluid_, JCAP **1207** (2012) 051 [DOI:10.1088/1475-7516/2012/07/051](https://doi.org/10.1088/1475-7516/2012/07/051), [arXiv:1004.2488](http://arxiv.org/abs/arXiv:1004.2488)
 
 The theory was subsqeuently developed in
 
-- Carrasco, Hertzberg & Senatore, _The Effective Field Theory of Cosmological Large Scale Structures_, JHEP **1209** (2012) 082 [DOI:10.1007/JHEP09(2012)082](http://dx.doi.org/10.1007/JHEP09(2012)082) [arXiv:1206.2926](http://arxiv.org/abs/arXiv:1206.2926)
+- Carrasco, Hertzberg & Senatore, _The Effective Field Theory of Cosmological Large Scale Structures_, JHEP **1209** (2012) 082 [DOI:10.1007/JHEP09(2012)082](https://doi.org/10.1007/JHEP09(2012)082) [arXiv:1206.2926](http://arxiv.org/abs/arXiv:1206.2926)
 
-- Carrasco, Foreman, Green & Senatore, _The Effective Field Theory of Large Scale Structures at Two Loops_, JCAP **1407** (2014) 057 [DOI:10.1088/1475-7516/2014/07/057](http://dx.doi.org/10.1088/1475-7516/2014/07/057) [arXiv:1310.0464](http://arxiv.org/abs/arXiv:1310.0464)
+- Carrasco, Foreman, Green & Senatore, _The Effective Field Theory of Large Scale Structures at Two Loops_, JCAP **1407** (2014) 057 [DOI:10.1088/1475-7516/2014/07/057](https://doi.org/10.1088/1475-7516/2014/07/057) [arXiv:1310.0464](http://arxiv.org/abs/arXiv:1310.0464)
 
 and other publications; for a fuller list, see the bibliography of
 [the paper linked above](#how-to-cite-lsseft). Details of the velocity power spectrum and its renormalization, which is important in redshift space, were studied by Mercolli & Pajer
 
-- Mercolli & Pajer, _On the velocity in the Effective Field Theory of Large Scale Structures_, JCAP **1403** (2014) 006 [DOI:10.1088/1475-7516/2014/03/006](http://dx.doi.org/10.1088/1475-7516/2014/03/006) [arXiv:1307.3220](http://arxiv.org/abs/arXiv:1307.3220)
+- Mercolli & Pajer, _On the velocity in the Effective Field Theory of Large Scale Structures_, JCAP **1403** (2014) 006 [DOI:10.1088/1475-7516/2014/03/006](https://doi.org/10.1088/1475-7516/2014/03/006) [arXiv:1307.3220](http://arxiv.org/abs/arXiv:1307.3220)
 
 
 The particular resummation scheme used by *LSSEFT* to damp the amplitude of baryonic acoustic oscillations by *LSSEFT* was proposed by Vlah et al.
 
-- Vlah, Seljak, Chu & Feng, _Perturbation theory, effective field theory, and oscillations in the power spectrum_, JCAP **1603** (2016) 057 [DOI:10.1088/1475-7516/2016/03/057](http://dx.doi.org/10.1088/1475-7516/2016/03/057) [arXiv:1509.02120](http://arxiv.org/abs/arXiv:1509.02120)
+- Vlah, Seljak, Chu & Feng, _Perturbation theory, effective field theory, and oscillations in the power spectrum_, JCAP **1603** (2016) 057 [DOI:10.1088/1475-7516/2016/03/057](https://doi.org/10.1088/1475-7516/2016/03/057) [arXiv:1509.02120](http://arxiv.org/abs/arXiv:1509.02120)
 
 see also
 
-- Senatore & Zaldarriaga, _The IR-resummed Effective Field Theory of Large Scale Structures_, JCAP **1502** (205) 013 [DOI:10.1088/1475-7516/2015/02/013](http://dx.doi.org/10.1088/1475-7516/2015/02/013) [arXiv:1404.5954](http://arxiv.org/abs/arXiv:1404.5954)
+- Senatore & Zaldarriaga, _The IR-resummed Effective Field Theory of Large Scale Structures_, JCAP **1502** (205) 013 [DOI:10.1088/1475-7516/2015/02/013](https://doi.org/10.1088/1475-7516/2015/02/013) [arXiv:1404.5954](http://arxiv.org/abs/arXiv:1404.5954)
 
 # Acknowledgements
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!